### PR TITLE
lazyZstore now uses console.error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
-## 1.6.4 
+## 1.7
+
+- sendError in `lazyZstate` now throws an error and sends an error to the console.
+
+## 1.6.4
 
 - fix camelCase so that it is compatable with safari
 
@@ -13,25 +17,25 @@ All notable changes to this project will be documented in this file.
 ## 1.5.0
 
 - Added Methods
-    - `kebabCase`
-    - `snakeCase`
-    - `camelCase`
-    - `titleCase`
-    - `numberStringList`
-    - `isInRange`
-    - `validPortRange`
-    - `lazyZstore`
+  - `kebabCase`
+  - `snakeCase`
+  - `camelCase`
+  - `titleCase`
+  - `numberStringList`
+  - `isInRange`
+  - `validPortRange`
+  - `lazyZstore`
 - Added methods to revision
-    - `setDoneCallback`
-    - `done`
+  - `setDoneCallback`
+  - `done`
 
 ## [1.3.0] - 2022 - 9 - 22
 
 - Added Methods:
-    - `flatten`
-    - `splatContains`
-    - `isArray`
-    - `revision`
+  - `flatten`
+  - `splatContains`
+  - `isArray`
+  - `revision`
 
 ## [1.2.0] - 2022 - 9 - 10
 
@@ -43,23 +47,23 @@ All notable changes to this project will be documented in this file.
 ## [1.1.0] - 2022-8-21
 
 - Added methods:
-    - `objectAtFirstKey`
-    - `isBoolean`
-    - `isString`
-    - `isIpv4CidrOrAddress`
-    - `keyValueType`
-    - `validIpv4Test`
-    - `splat`
-    - `spreadKeyValues`
-    - `hasDuplicateKeys`
-    - `duplicateKeyTest`
-    - `arraySplatIndex`
-    - `getObjectFromArray`
-    - `carve`
+  - `objectAtFirstKey`
+  - `isBoolean`
+  - `isString`
+  - `isIpv4CidrOrAddress`
+  - `keyValueType`
+  - `validIpv4Test`
+  - `splat`
+  - `spreadKeyValues`
+  - `hasDuplicateKeys`
+  - `duplicateKeyTest`
+  - `arraySplatIndex`
+  - `getObjectFromArray`
+  - `carve`
 
 ## [1.0.4] - 2022-8-18
 
 - Added methods:
-    - `transpose`
-    - `isEmpty`
-    - `emptyCheck`
+  - `transpose`
+  - `isEmpty`
+  - `emptyCheck`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## 1.7
 
 - sendError in `lazyZstate` now throws an error and sends an error to the console.
+- setErrorCallback now runs in sendError and does not override sendError
 
 ## 1.6.4
 

--- a/README.md
+++ b/README.md
@@ -75,12 +75,14 @@ lazy-z is a light-weight NodeJS library for assorted shortcuts and utilities
    - [getVerbActions](#getVerbActions)
    - [replaceOptionalFlags](#replaceoptionalflags)
 10. [Array Methods](#array-methods)
-   - [numberStringList](#numberStringList)
-   - [flatten](#flatten)
+
+- [numberStringList](#numberStringList)
+- [flatten](#flatten)
+
 11. [lazyZstate](#lazyZstate)
 12. [axios mocks](#axios-mocks)
-12. [Contributing](#contributing)
-13. [Code Test Coverage](#code-test-coverage)
+13. [Contributing](#contributing)
+14. [Code Test Coverage](#code-test-coverage)
 
 ---
 
@@ -463,7 +465,6 @@ let testData = {
 new revision(testData).updateEachChild("friends", (friend) => {
   friend.high_score = 0;
 });
-
 ```
 
 ### revision.updateEachNestedChild
@@ -473,19 +474,25 @@ Update each nested child within any depth of arrays.
 ```js
 const { revision } = require("lazy-z");
 let testData = {
-  a: [{
-      b: [{
-        c: [{ test: "true" }]
-      }]
+  a: [
+    {
+      b: [
+        {
+          c: [{ test: "true" }],
+        },
+      ],
     },
     {
-      b: [{
-        c: [{ test: "true" }]
-      },{
-        c: [{ test: "true" }],
-      }]
-    }
-  ]
+      b: [
+        {
+          c: [{ test: "true" }],
+        },
+        {
+          c: [{ test: "true" }],
+        },
+      ],
+    },
+  ],
 };
 
 new revision(testData).updateEachNestedChild(["a", "b", "c"], (entry) => {
@@ -494,19 +501,25 @@ new revision(testData).updateEachNestedChild(["a", "b", "c"], (entry) => {
 
 // updates test data value to
 {
-  a: [{
-      b: [{
-        c: [{ test: false }]
-      }]
+  a: [
+    {
+      b: [
+        {
+          c: [{ test: false }],
+        },
+      ],
     },
     {
-      b: [{
-        c: [{ test: false }]
-      },{
-        c: [{ test: false }],
-      }]
-    }
-  ]
+      b: [
+        {
+          c: [{ test: false }],
+        },
+        {
+          c: [{ test: false }],
+        },
+      ],
+    },
+  ];
 }
 ```
 
@@ -563,8 +576,8 @@ Check to see if two values have all fields equal.
 ```js
 const { deepEqual } = require("lazy-z");
 
-deepEqual({ foo: "bar" }, { foo: "baz" }) // returns false
-deepEqual({ foo: "bar" }, { foo: "bar" }) // returns true
+deepEqual({ foo: "bar" }, { foo: "baz" }); // returns false
+deepEqual({ foo: "bar" }, { foo: "bar" }); // returns true
 ```
 
 ### distinct
@@ -574,11 +587,9 @@ Returns all distinct entries in an array
 ```js
 const { disctinct } = require("lazy-z");
 
-distinct(["c", "a", "b", "b", "a", "g", "e"])
-
-// returns
-[
-  "c", "a", "b", "g", "e"
+distinct(["c", "a", "b", "b", "a", "g", "e"])[
+  // returns
+  ("c", "a", "b", "g", "e")
 ];
 ```
 
@@ -796,7 +807,7 @@ containsCheck(
   "should contain the number 4",
   ["frog", "string", "egg"],
   "4"
-)// throws
+) // throws
 `should contain the number 4 got ["frog", "string", "egg"]`;
 ```
 
@@ -807,7 +818,10 @@ Test to see if an array is empty. Throw an error if it is.
 ```js
 const { emptyCheck } = require("lazy-z");
 
-emptyCheck("array should not be empty", [])// throws
+emptyCheck(
+  "array should not be empty",
+  []
+) // throws
 `array should not be empty`;
 ```
 
@@ -895,7 +909,6 @@ typeCheck(
 ## String Methods
 
 Methods for dealing with strings
-
 
 ### camelCase
 
@@ -991,7 +1004,7 @@ stringify(
 
 ### titleCase
 
-Format a string from from `all-caps-with-spaces` to `All Caps With Spaces` 
+Format a string from from `all-caps-with-spaces` to `All Caps With Spaces`
 
 ```js
 const { titleCase } = require("lazy-z");
@@ -1018,32 +1031,31 @@ const { isInRange } = require("lazy-z");
 
 isInRange(1.5, 1, 2); // value, min, max
 // returns
-true
+true;
 ```
 
 ### validPortRange
 
-Check if a port range is valid. 
+Check if a port range is valid.
 
 ```js
 const { validPortRange } = require("lazy-z");
 
 validPortRange(
   // can be one of ["type","code","port_min","port_max","source_port_min","source_port_max"]
-  "port_min", 
+  "port_min",
   8080
-)
+);
 // returns
-true
+true;
 
 validPortRange(
   // can be one of ["type","code","port_min","port_max","source_port_min","source_port_max"]
-  "type", 
+  "type",
   257
-)
+);
 // returns
-false
-
+false;
 ```
 
 ---
@@ -1244,8 +1256,7 @@ splatContains(
   ],
   "name",
   "egg"
-)
-
+);
 ```
 
 ### spreadKeyValues
@@ -1591,11 +1602,11 @@ const { numberStringList } = require("lazy-z");
 
 numberStringList(5);
 // returns
-["0", "1", "2","3", "4"];
+["0", "1", "2", "3", "4"];
 
-numberStringList(5,1);
+numberStringList(5, 1);
 // returns
-["1", "2","3", "4", "5"];
+["1", "2", "3", "4", "5"];
 ```
 
 ### flatten
@@ -1725,22 +1736,87 @@ let state = new lazyZstate();
 let callback = () => {
   console.log("hi");
 };
-slz.setUpdateCallback(callback);
-slz.update();
+state.setUpdateCallback(callback);
+state.update();
 
 // on update logs
 `hi`
+```
+
+### lazyZstate.sendError
+
+Logs errors to the console, if an error callback is set, runs it, otherwise throws the error as well
+
+```js
+/**
+ * send an error
+ * @param {Error} err error
+ * @throws when message provided
+ */
+this.sendError = function (err) {
+  console.error(err);
+  if (this.sendErrorCallback) this.sendErrorCallback(err);
+  else throw new Error(err);
+};
+```
+
+#### Example Usage
+
+```js
+const = { lazyZstate } = require("lazy-z");
+
+let state = new lazyZstate();
+state.sendError("error");
+
+// errors
+`error`
+// throws
+`Error: error`
+```
+
+### lazyZstate.setErrorCallback
+
+Set an error callback function to run when an error is sent
+
+```js
+/**
+ * set callback for error handling
+ * @param {setErrorCallback} callback callback function
+ */
+this.setErrorCallback = function (callback) {
+  paramTest(`lazyZstate.setErrorCallback`, "callback", "Function", callback);
+  this.sendErrorCallback = callback;
+};
+```
+
+#### Example Usage
+
+```js
+const = { lazyZstate } = require("lazy-z");
+
+let state = new lazyZstate();
+let callback = () => {
+  console.log("hi from callback");
+};
+state.setErrorCallback(callback);
+state.sendError();
+
+// errors
+`hi`
+// logs
+`hi from callback`
 ```
 
 ---
 
 ## Axios Mocks
 
-`lazy-z` provides a test framework for creating mock [axios](https://www.npmjs.com/package/axios) calls. 
+`lazy-z` provides a test framework for creating mock [axios](https://www.npmjs.com/package/axios) calls.
 
 ### Initializing the Constructor
 
 The mock axios constructor can be initialized with two parameters:
+
 - `data` - an arbitrary object of data to be returned when the promise resolves
 - `err` - an optional boolean. By setting this value to true, the data passed in as `data` will be sent on rejection instead of resolve.
 
@@ -1782,11 +1858,9 @@ describe("axios", () => {
     return axios({ params: "yes" }).catch((data) => {
       assert.isTrue(data.data, "it should be true");
     });
-  });  
+  });
 });
 ```
-
-
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -75,10 +75,8 @@ lazy-z is a light-weight NodeJS library for assorted shortcuts and utilities
    - [getVerbActions](#getVerbActions)
    - [replaceOptionalFlags](#replaceoptionalflags)
 10. [Array Methods](#array-methods)
-
-- [numberStringList](#numberStringList)
-- [flatten](#flatten)
-
+    - [numberStringList](#numberStringList)
+    - [flatten](#flatten)
 11. [lazyZstate](#lazyZstate)
 12. [axios mocks](#axios-mocks)
 13. [Contributing](#contributing)
@@ -1884,14 +1882,16 @@ example:
 
 ## Code Test Coverage
 
-| File         | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s |
-| ------------ | ------- | -------- | ------- | ------- | ----------------- |
-| All files    | 100     | 100      | 100     | 100     | 🏆                |
-| arrays.js    | 100     | 100      | 100     | 100     | 🏆                |
-| cli-utils.js | 100     | 100      | 100     | 100     | 🏆                |
-| encode.js    | 100     | 100      | 100     | 100     | 🏆                |
-| objects.js   | 100     | 100      | 100     | 100     | 🏆                |
-| revision.js  | 100     | 100      | 100     | 100     | 🏆                |
-| shortcuts.js | 100     | 100      | 100     | 100     | 🏆                |
-| strings.js   | 100     | 100      | 100     | 100     | 🏆                |
-| values.js    | 100     | 100      | 100     | 100     | 🏆                |
+| File           | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s |
+| -------------- | ------- | -------- | ------- | ------- | ----------------- |
+| All files      | 100     | 100      | 100     | 100     | 🏆                |
+| arrays.js      | 100     | 100      | 100     | 100     | 🏆                |
+| axios-mocks.js | 100     | 100      | 100     | 100     | 🏆                |
+| cli-utils.js   | 100     | 100      | 100     | 100     | 🏆                |
+| encode.js      | 100     | 100      | 100     | 100     | 🏆                |
+| numbers.js     | 100     | 100      | 100     | 100     | 🏆                |
+| objects.js     | 100     | 100      | 100     | 100     | 🏆                |
+| revision.js    | 100     | 100      | 100     | 100     | 🏆                |
+| shortcuts.js   | 100     | 100      | 100     | 100     | 🏆                |
+| strings.js     | 100     | 100      | 100     | 100     | 🏆                |
+| values.js      | 100     | 100      | 100     | 100     | 🏆                |

--- a/lib/revision.js
+++ b/lib/revision.js
@@ -229,9 +229,9 @@ function revision(arrayOrObject, parent) {
    */
   this.setDoneCallback = (callback) => {
     paramTest("revision.setDoneCallback", "callback", "Function", callback);
-    this.done = function() {
+    this.done = function () {
       callback(this.data);
-    }
+    };
     return this;
   };
 
@@ -239,7 +239,9 @@ function revision(arrayOrObject, parent) {
    * function to call when done
    */
   this.done = function () {
-    throw new Error(`revision expected revision.setDoneCallback to be initialized before done is called`);
+    throw new Error(
+      `revision expected revision.setDoneCallback to be initialized before done is called`
+    );
   };
 }
 

--- a/lib/store.js
+++ b/lib/store.js
@@ -1,6 +1,7 @@
 const { revision } = require("./revision");
 const { eachKey, contains, keys, containsKeys } = require("./shortcuts");
 const { paramTest } = require("./values");
+const sinon = require("sinon");
 
 /**
  * create an initial store
@@ -11,7 +12,7 @@ const { paramTest } = require("./values");
  * @param {string=} parent override function name
  * @returns {object} key value pairs for store data
  */
-function createStore(defaults, store, parent) {
+function createStore(defaults, store, parent, options) {
   let functionName = parent || "createStore";
   paramTest(functionName, "defaults", "object", defaults);
   // check for store is object if
@@ -32,7 +33,7 @@ function createStore(defaults, store, parent) {
     store: {},
   };
   // set defaults on store and return data
-  new revision(data).set("store", defaults, store);
+  new revision(data).set("store", defaults, store, options);
   return data.store;
 }
 
@@ -120,8 +121,9 @@ function storeTemplate(state, field, params, parentStore) {
  * @param {object=} defaults._defaults key value pairs of default values for store
  * @param {Array<string>=} defaults._no_default list of values in store to set to `null`
  * @param {object=} store arbitrary key value pairs to add to store object. values are added after defaults
+ * @param {object=} options object of options to turn on, key is option, value is value
  */
-function lazyZstate(defaults, store) {
+function lazyZstate(defaults, store, options) {
   this.store = {}; // store data
   this.updateFunctions = []; // update functions
   /**
@@ -132,7 +134,12 @@ function lazyZstate(defaults, store) {
    * @param {object=} storeData arbitrary key value pairs to add to store object. values are added after defaults
    */
   this.initStore = function (storeDefaults, storeData) {
-    this.store = createStore(storeDefaults || {}, storeData, "state.initStore");
+    this.store = createStore(
+      storeDefaults || {},
+      storeData,
+      "state.initStore",
+      options
+    );
   };
 
   /**
@@ -166,11 +173,13 @@ function lazyZstate(defaults, store) {
 
   /**
    * send an error
-   * @param {string} message error message
+   * @param {Error} err error
    * @throws when message provided
    */
-  this.sendError = function (message) {
-    throw new Error(message);
+  this.sendError = function (err) {
+    console.error(err);
+    if (this.sendErrorCallback) this.sendErrorCallback(err);
+    else throw new Error(err);
   };
 
   /**
@@ -220,6 +229,14 @@ function lazyZstate(defaults, store) {
     });
     return revise;
   };
+
+  if (typeof options === Object) {
+    console.log("hi from line 230");
+    console.log(options);
+    Object.entries(options).forEach((key, value) => {
+      this[key] = value;
+    });
+  }
 
   // run init store on creation
   this.initStore(defaults, store);

--- a/lib/store.js
+++ b/lib/store.js
@@ -141,7 +141,7 @@ function lazyZstate(defaults, store, options) {
     );
     if (options) {
       Object.keys(options).forEach((option) => {
-        this[option] = options[option]; //
+        this[option] = options[option]; // set the value of the option to what it is defined as
       });
     }
   };

--- a/lib/store.js
+++ b/lib/store.js
@@ -1,7 +1,6 @@
 const { revision } = require("./revision");
 const { eachKey, contains, keys, containsKeys } = require("./shortcuts");
 const { paramTest } = require("./values");
-const sinon = require("sinon");
 
 /**
  * create an initial store
@@ -140,6 +139,11 @@ function lazyZstate(defaults, store, options) {
       "state.initStore",
       options
     );
+    if (options) {
+      Object.keys(options).forEach((option) => {
+        this[option] = options[option]; //
+      });
+    }
   };
 
   /**
@@ -229,14 +233,6 @@ function lazyZstate(defaults, store, options) {
     });
     return revise;
   };
-
-  if (typeof options === Object) {
-    console.log("hi from line 230");
-    console.log(options);
-    Object.entries(options).forEach((key, value) => {
-      this[key] = value;
-    });
-  }
 
   // run init store on creation
   this.initStore(defaults, store);

--- a/lib/store.js
+++ b/lib/store.js
@@ -11,7 +11,7 @@ const { paramTest } = require("./values");
  * @param {string=} parent override function name
  * @returns {object} key value pairs for store data
  */
-function createStore(defaults, store, parent, options) {
+function createStore(defaults, store, parent) {
   let functionName = parent || "createStore";
   paramTest(functionName, "defaults", "object", defaults);
   // check for store is object if
@@ -32,7 +32,7 @@ function createStore(defaults, store, parent, options) {
     store: {},
   };
   // set defaults on store and return data
-  new revision(data).set("store", defaults, store, options);
+  new revision(data).set("store", defaults, store);
   return data.store;
 }
 
@@ -122,7 +122,7 @@ function storeTemplate(state, field, params, parentStore) {
  * @param {object=} store arbitrary key value pairs to add to store object. values are added after defaults
  * @param {object=} options object of options to turn on, key is option, value is value
  */
-function lazyZstate(defaults, store, options) {
+function lazyZstate(defaults, store) {
   this.store = {}; // store data
   this.updateFunctions = []; // update functions
   /**
@@ -133,17 +133,7 @@ function lazyZstate(defaults, store, options) {
    * @param {object=} storeData arbitrary key value pairs to add to store object. values are added after defaults
    */
   this.initStore = function (storeDefaults, storeData) {
-    this.store = createStore(
-      storeDefaults || {},
-      storeData,
-      "state.initStore",
-      options
-    );
-    if (options) {
-      Object.keys(options).forEach((option) => {
-        this[option] = options[option]; // set the value of the option to what it is defined as
-      });
-    }
+    this.store = createStore(storeDefaults || {}, storeData, "state.initStore");
   };
 
   /**
@@ -192,7 +182,7 @@ function lazyZstate(defaults, store, options) {
    */
   this.setErrorCallback = function (callback) {
     paramTest(`lazyZstate.setErrorCallback`, "callback", "Function", callback);
-    this.sendError = callback;
+    this.sendErrorCallback = callback;
   };
 
   /**
@@ -221,17 +211,6 @@ function lazyZstate(defaults, store, options) {
    */
   this.newField = function (field, params) {
     storeTemplate(this, field, params);
-  };
-
-  /**
-   * revise the store and set .done() function to run update
-   * @returns {revision} revision against store
-   */
-  this.reviseStore = function () {
-    let revise = new revision(this.store).setDoneCallback(() => {
-      this.update();
-    });
-    return revise;
   };
 
   // run init store on creation

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lazy-z",
-  "version": "1.5.2",
+  "version": "1.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "lazy-z",
-      "version": "1.5.2",
+      "version": "1.7.0",
       "license": "ISC",
       "dependencies": {
         "regex-but-with-words": "^1.5.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lazy-z",
-  "version": "1.6.7",
+  "version": "1.7.0",
   "description": "lazy-z is a light-weight NodeJS library for assorted shortcuts and utilities",
   "main": "index.js",
   "scripts": {

--- a/unit-tests/store.test.js
+++ b/unit-tests/store.test.js
@@ -222,6 +222,18 @@ describe("store", () => {
         let task = () => new lazyZstate().sendError("hi");
         assert.throws(task, "hi");
       });
+      it("should call error callback if one is set", () => {
+        let spy = sinon.spy();
+        let store = new lazyZstate(
+          { _no_default: ["todd"] }, // defaults
+          {}, // store
+          {
+            sendErrorCallback: spy,
+          }
+        );
+        store.sendError("hi");
+        assert.isTrue(spy.calledOnce, "it should be called");
+      });
     });
     describe("setErrorCallback", () => {
       it("should set sendError", () => {

--- a/unit-tests/store.test.js
+++ b/unit-tests/store.test.js
@@ -174,11 +174,12 @@ describe("store", () => {
         assert.deepEqual(actualData, expectedData, "it should be empty object");
       });
       it("should create a store with an sendErrorCallback if set in options", () => {
-        let actualData = new lazyZstate(
-          {}, // defaults
+        let store = new lazyZstate(
+          { _no_default: ["todd"] }, // defaults
           {}, // store
           { sendErrorCallback: () => {} }
         );
+        assert.hasAnyKeys(store, "sendErrorCallback"); // ensure this key is added
       });
     });
     describe("setUpdateCallback", () => {

--- a/unit-tests/store.test.js
+++ b/unit-tests/store.test.js
@@ -173,14 +173,6 @@ describe("store", () => {
         let expectedData = {};
         assert.deepEqual(actualData, expectedData, "it should be empty object");
       });
-      it("should create a store with an sendErrorCallback if set in options", () => {
-        let store = new lazyZstate(
-          { _no_default: ["todd"] }, // defaults
-          {}, // store
-          { sendErrorCallback: () => {} }
-        );
-        assert.hasAnyKeys(store, "sendErrorCallback"); // ensure this key is added
-      });
     });
     describe("setUpdateCallback", () => {
       it("should set the update callback", () => {
@@ -222,26 +214,14 @@ describe("store", () => {
         let task = () => new lazyZstate().sendError("hi");
         assert.throws(task, "hi");
       });
-      it("should call error callback if one is set", () => {
-        let spy = sinon.spy();
-        let store = new lazyZstate(
-          { _no_default: ["todd"] }, // defaults
-          {}, // store
-          {
-            sendErrorCallback: spy,
-          }
-        );
-        store.sendError("hi");
-        assert.isTrue(spy.calledOnce, "it should be called");
-      });
     });
     describe("setErrorCallback", () => {
-      it("should set sendError", () => {
-        let slz = new lazyZstate();
-        slz.setErrorCallback(() => {
-          return "hi";
-        });
-        assert.deepEqual(slz.sendError(), "hi", "it should set value");
+      it("should call error callback if one is set", () => {
+        let spy = sinon.spy();
+        let store = new lazyZstate();
+        store.setErrorCallback(spy);
+        store.sendError("hi");
+        assert.isTrue(spy.calledOnce, "it should be called");
       });
     });
     describe("tryCatch", () => {
@@ -272,36 +252,6 @@ describe("store", () => {
         slz.newField("frog", { init: initSpy });
         assert.isTrue(initSpy.calledOnce, "it should be called");
         assert.isTrue(slz.frog !== null, "it should not be null");
-      });
-    });
-    describe("reviseStore", () => {
-      it("should revise data and run update function when done is called", () => {
-        let slz = new lazyZstate();
-        let expectedData = {
-          frog: {
-            foo: "bar",
-          },
-        };
-        let updateSpy = new sinon.spy();
-        slz.setUpdateCallback(() => {});
-        slz.updateFunctions.push(updateSpy);
-        slz.reviseStore().set("frog", { foo: "bar" }).done();
-        assert.deepEqual(
-          slz.store,
-          expectedData,
-          "it should have the correct data"
-        );
-        assert.isTrue(updateSpy.calledOnce, "it should be called");
-      });
-    });
-    describe("everything", () => {
-      it("should revise correctly with no error thrown", () => {
-        let store = new lazyZstate();
-        store.setUpdateCallback(() => {});
-        let task = () => {
-          store.reviseStore().done();
-        };
-        assert.doesNotThrow(task, "it should not throw");
       });
     });
   });

--- a/unit-tests/store.test.js
+++ b/unit-tests/store.test.js
@@ -173,6 +173,13 @@ describe("store", () => {
         let expectedData = {};
         assert.deepEqual(actualData, expectedData, "it should be empty object");
       });
+      it("should create a store with an sendErrorCallback if set in options", () => {
+        let actualData = new lazyZstate(
+          {}, // defaults
+          {}, // store
+          { sendErrorCallback: () => {} }
+        );
+      });
     });
     describe("setUpdateCallback", () => {
       it("should set the update callback", () => {


### PR DESCRIPTION
- `state.sendError` now uses `console.error` and only throws an error if a callback is not set
- if a callback is set, it now runs within `state.sendError` instead of overriding `state.sendError`
- removed state.revise and corresponding unit tests
- added documentation to readme and changes in changelog
- fixed some typos in the readme that referenced variables that didn't exist in example code (references to slz instead of state)
- updated trophies to include all files in test coverage, a few were missing